### PR TITLE
Move screenshots to artifacts directory

### DIFF
--- a/bin/wordpress-at-scale-auto-update.sh
+++ b/bin/wordpress-at-scale-auto-update.sh
@@ -32,7 +32,7 @@ else
 
     # apply WordPress upstream updates
     echo -e "\nApplying upstream updates on the ${MULTIDEV} multidev..."
-    terminus site upstream-updates apply --yes --updatedb --accept-upstream
+    terminus site upstream-updates apply --yes --updatedb --accept-upstream --env=${MULTIDEV}
     UPDATES_APPLIED=true
 fi
 
@@ -107,6 +107,9 @@ else
     VISUAL_REGRESSION_RESULTS=$(npm run test)
 
     echo "${VISUAL_REGRESSION_RESULTS}"
+
+    echo "Rsyncing Backstop results to artifacts directory"
+    rsync  -rlvz   /home/ubuntu/wordpress-at-scale-auto-update/backstop_data $CIRCLE_ARTIFACTS/backstop
 
     cd -
     if [[ ${VISUAL_REGRESSION_RESULTS} == *"Mismatch errors found"* ]]

--- a/circle.yml
+++ b/circle.yml
@@ -15,18 +15,15 @@ dependencies:
     - /home/ubuntu/nvm/versions/node/4.4.7/lib/node_modules
 
   pre:
-
     # Install gulp
     - echo Installing gulp globally
     - npm install -g gulp
 
+  override:
     # Install Terminus
     - sudo curl https://github.com/pantheon-systems/terminus/releases/download/0.11.4/terminus.phar -L -o /usr/local/bin/terminus
     - sudo chmod +x /usr/local/bin/terminus
 
-  override:
-    - ./bin/wordpress-at-scale-auto-update.sh
-
 test:
   override:
-    - ls
+    - ./bin/wordpress-at-scale-auto-update.sh


### PR DESCRIPTION
I walked an agency through this repo during a fast track a couple of weeks ago. The site genuinely failed the screenshot test when upgrading core. We made a change like this to get the screenshots actually visible.