### PR TITLE
Removing extraneous parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pantheon WordPress Auto Update #
 
 ## Description ##
-Automate WordPress core, plugin and theme updates on [Pantheon](https://pantheon.io)) with Terminus, CircleCI, WP-CLI, BackstopJS and Slack.
+Automate WordPress core, plugin and theme updates on [Pantheon](https://pantheon.io) with Terminus, CircleCI, WP-CLI, BackstopJS and Slack.
 
 This script will:
 


### PR DESCRIPTION
In the first line of README.md, there is an extra parentheses. It was probably a typo when adding a link to "Pantheon".