### PR TITLE
Updated to supported latest version of PHP7

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
     version: 6.1.0
 
   php:
-      version: 7.0.4
+      version: 7.0.24
 
   environment:
     PATH: "${PATH}:${HOME}/terminus/bin"


### PR DESCRIPTION
Was 7.0.4, that produces an error with CircleCI 1
updated to most recent update for 7.0, which is 7.0.24
List is here:
https://circleci.com/docs/1.0/build-image-trusty/#php