### PR TITLE
Update PHP to 7.0.24

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
     version: 6.1.0
 
   php:
-      version: 7.0.4
+      version: 7.0.24
 
   environment:
     PATH: "${PATH}:${HOME}/terminus/bin"


### PR DESCRIPTION
PHP 7.0.4 has been removed from Ubuntu 14.0.4: https://discuss.circleci.com/t/ubuntu-14-04-build-image-update-201710-01/17609. Updating PHP to 7.0.24.